### PR TITLE
feat: add Akeyless loaders (static, dynamic, rotated)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,6 @@ coverage/*
 **/*.config.js
 
 example.js
+
+# Jest setup: plain JS, not part of TypeScript project
+tests/setup/slow-buffer-shim.js

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ VAULT_VALUE = ${vault:/path/to/secret}
 // Use a static secret from Akeyless (set AKEYLESS_ACCESS_ID / AKEYLESS_ACCESS_KEY or AKEYLESS_TOKEN)
 API_KEY = ${akeyless:/prod/my-app/api-key}
 
+// Dynamic secret (JSON string: credentials payload). Prefix uses underscores so it matches ${...} rules.
+DB_CREDS = ${akeyless_dynamic(timeout=30,args=--k=v|other):/dyn/postgres}
+
+// Rotated secret (JSON string). Optional host for linked targets (or AKEYLESS_ROTATED_SECRET_HOST).
+ROTATED = ${akeyless_rotated(host=my.db.host):/rotated/mysql}
+
 ```
 
 - If you were earlier running your application using `node app.js`, use:
@@ -115,7 +121,7 @@ SecretsFoundry currently provides support for the following sources:
 3. Hashicorp Vault
 4. AWS S3
 5. Google Secret Manager
-6. Akeyless (static secrets via `get-secret-value`)
+6. Akeyless — static (`akeyless:`), dynamic (`akeyless_dynamic:`), and rotated (`akeyless_rotated:`) secrets
 
 We will soon be extending support for Azure Key Vault. If you need support
 for other sources, reach out to us for support or send a PR.
@@ -146,10 +152,17 @@ AWS_S3_VALUE = ${aws-s3:bucket/key}
 // Use value from Hashicorp vault
 VAULT_VALUE = ${vault:/path/to/secret}
 
-// Akeyless static secret — env: AKEYLESS_GATEWAY_URL (optional), AKEYLESS_TOKEN or AKEYLESS_ACCESS_ID + AKEYLESS_ACCESS_KEY
+// Akeyless static — env: AKEYLESS_GATEWAY_URL (optional), AKEYLESS_TOKEN or AKEYLESS_ACCESS_ID + AKEYLESS_ACCESS_KEY
 // Args: gateway, ignore-cache, json, version
-// Example: ${akeyless(gateway=https://gateway.example.com:8080/v2):/path/to/secret}
 AKEYLESS_SECRET = ${akeyless:/path/to/secret}
+
+// Akeyless dynamic — response is JSON string. Args: gateway, timeout, args (pipe-separated), host, dbname, target, json
+// Env fallbacks: AKEYLESS_DYNAMIC_TIMEOUT, AKEYLESS_DYNAMIC_ARGS (pipe-separated)
+AKEYLESS_DYNAMIC = ${akeyless_dynamic(timeout=45):/path/to/dynamic-secret}
+
+// Akeyless rotated — response is JSON string. Args: gateway, host, ignore-cache, json, version
+// Env: AKEYLESS_ROTATED_SECRET_HOST when host is not passed as an arg
+AKEYLESS_ROTATED = ${akeyless_rotated:/path/to/rotated-secret}
 ```
 
 ## Advanced Usage:

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ VARIABLE = "simple"
 GOOGLE_API_KEY = google_api_key
 ```
 
-You can similarily store your variables in AWS S3, AWS Secrets Manager and Hashicorp Vault.
-To use them as environment variables, you can simple use:
+You can similarly store your variables in AWS S3, AWS Secrets Manager, Hashicorp Vault, Google Secret Manager, or Akeyless.
+To use them as environment variables, you can simply use:
 
 ```js
 
@@ -82,6 +82,9 @@ AWS_S3_VALUE = ${aws-s3:bucket/key}
 
 // Use value from Hashicorp vault
 VAULT_VALUE = ${vault:/path/to/secret}
+
+// Use a static secret from Akeyless (set AKEYLESS_ACCESS_ID / AKEYLESS_ACCESS_KEY or AKEYLESS_TOKEN)
+API_KEY = ${akeyless:/prod/my-app/api-key}
 
 ```
 
@@ -111,8 +114,10 @@ SecretsFoundry currently provides support for the following sources:
 2. AWS Secrets Manager
 3. Hashicorp Vault
 4. AWS S3
+5. Google Secret Manager
+6. Akeyless (static secrets via `get-secret-value`)
 
-We will soon be extending support for GCP Secrets Engine and Azure Key Vault. If you need support
+We will soon be extending support for Azure Key Vault. If you need support
 for other sources, reach out to us for support or send a PR.
 
 ## Format in env files
@@ -140,6 +145,11 @@ AWS_S3_VALUE = ${aws-s3:bucket/key}
 
 // Use value from Hashicorp vault
 VAULT_VALUE = ${vault:/path/to/secret}
+
+// Akeyless static secret — env: AKEYLESS_GATEWAY_URL (optional), AKEYLESS_TOKEN or AKEYLESS_ACCESS_ID + AKEYLESS_ACCESS_KEY
+// Args: gateway, ignore-cache, json, version
+// Example: ${akeyless(gateway=https://gateway.example.com:8080/v2):/path/to/secret}
+AKEYLESS_SECRET = ${akeyless:/path/to/secret}
 ```
 
 ## Advanced Usage:

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ SecretsFoundry currently provides support for the following sources:
 5. Google Secret Manager
 6. Akeyless — static (`akeyless:`), dynamic (`akeyless_dynamic:`), and rotated (`akeyless_rotated:`) secrets
 
+For a single CLI run, the Akeyless loader **reuses one authenticated session** (same gateway and credentials) across all `${akeyless…}` / `${akeyless_dynamic…}` / `${akeyless_rotated…}` resolutions so `/auth` is not repeated per variable.
+
 We will soon be extending support for Azure Key Vault. If you need support
 for other sources, reach out to us for support or send a PR.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   coverageProvider: 'v8',
   preset: 'ts-jest',
   clearMocks: true,
+  setupFiles: ['<rootDir>/tests/setup/slow-buffer-shim.js'],
   testEnvironment: 'node',
   roots: ['<rootDir>/'],
   moduleFileExtensions: ['ts', 'js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "secretsfoundry",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "secretsfoundry",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^5.3.0",
         "@types/flat": "^5.0.2",
+        "akeyless": "^5.0.25",
         "aws-sdk": "^2.1002.0",
         "chalk": "^4.1.2",
         "commander": "^8.2.0",
@@ -43,6 +44,81 @@
         "node": ">=16"
       }
     },
+    "node_modules/@babel/cli": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.6.tgz",
+      "integrity": "sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "commander": "^6.2.0",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.6.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/cli/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -56,7 +132,6 @@
       "version": "7.14.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
       "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -65,7 +140,7 @@
       "version": "7.14.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
       "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
@@ -95,7 +170,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.14.5"
       },
@@ -107,7 +181,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -116,7 +189,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -125,7 +197,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
       "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -140,7 +211,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
       "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
-      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
@@ -158,7 +228,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -167,7 +236,6 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -176,7 +244,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
         "@babel/types": "^7.23.0"
@@ -189,7 +256,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -201,7 +267,6 @@
       "version": "7.14.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
       "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -213,7 +278,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
       "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -225,7 +289,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
       "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.14.5",
         "@babel/helper-replace-supers": "^7.14.5",
@@ -244,7 +307,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
       "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -265,7 +327,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
       "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.14.5",
         "@babel/helper-optimise-call-expression": "^7.14.5",
@@ -280,7 +341,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
       "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -292,7 +352,6 @@
       "version": "7.22.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -304,7 +363,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
       "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -313,7 +371,6 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -322,7 +379,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
       "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -331,7 +387,6 @@
       "version": "7.14.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
       "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.5",
@@ -345,7 +400,6 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
       "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -359,7 +413,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -371,7 +424,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -385,7 +437,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -393,14 +444,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -409,7 +458,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -418,7 +466,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -430,7 +477,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
       "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -604,7 +650,6 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/parser": "^7.22.15",
@@ -618,7 +663,6 @@
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
       "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.13",
         "chalk": "^2.4.2"
@@ -631,7 +675,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -643,7 +686,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -657,7 +699,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -665,14 +706,12 @@
     "node_modules/@babel/template/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/template/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -681,7 +720,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -690,7 +728,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -702,7 +739,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
       "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
@@ -723,7 +759,6 @@
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
       "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.13",
         "chalk": "^2.4.2"
@@ -736,7 +771,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -748,7 +782,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -762,7 +795,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -770,14 +802,12 @@
     "node_modules/@babel/traverse/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/traverse/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -786,7 +816,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -795,7 +824,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -804,7 +832,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -816,7 +843,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
       "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -1228,7 +1254,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1242,7 +1267,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1251,7 +1275,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1259,14 +1282,13 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-      "dev": true,
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1280,6 +1302,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1592,7 +1621,8 @@
     "node_modules/@types/node": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.2.tgz",
-      "integrity": "sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw=="
+      "integrity": "sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw==",
+      "peer": true
     },
     "node_modules/@types/prettier": {
       "version": "2.3.2",
@@ -1655,6 +1685,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
       "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "4.28.3",
         "@typescript-eslint/scope-manager": "4.28.3",
@@ -1710,6 +1741,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
       "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.28.3",
         "@typescript-eslint/types": "4.28.3",
@@ -1828,6 +1860,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1887,6 +1920,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/akeyless": {
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/akeyless/-/akeyless-5.0.25.tgz",
+      "integrity": "sha512-R0PFcOyvNSx2khvSZRIg4Hastbg1GWSj+/MwvbUKQVmWpJ9H2onJe6qwe6fkPHAqLdbiFD5ms7k7x6pkWhU/TQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@babel/cli": "^7.0.0",
+        "superagent": "^5.3.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -1951,7 +1994,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2172,8 +2215,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2210,11 +2252,23 @@
         "node": "*"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2224,7 +2278,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -2250,7 +2304,6 @@
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
       "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
@@ -2323,6 +2376,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2345,7 +2427,6 @@
       "version": "1.0.30001245",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
       "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -2378,6 +2459,31 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ci-info": {
@@ -2438,8 +2544,7 @@
     "node_modules/colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2460,20 +2565,33 @@
         "node": ">= 12"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -2680,6 +2798,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexify": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
@@ -2711,8 +2843,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.3.775",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.775.tgz",
-      "integrity": "sha512-EGuiJW4yBPOTj2NtWGZcX93ZE8IGj33HJAx4d3ouE2zOfW2trbWU+t1e0yzLr1qQIw81++txbM3BH52QwSRE6Q==",
-      "dev": true
+      "integrity": "sha512-EGuiJW4yBPOTj2NtWGZcX93ZE8IGj33HJAx4d3ouE2zOfW2trbWU+t1e0yzLr1qQIw81++txbM3BH52QwSRE6Q=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -2749,6 +2880,36 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2858,6 +3019,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
       "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
@@ -3225,6 +3387,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
@@ -3259,7 +3427,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3336,7 +3504,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3346,17 +3513,31 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "license": "MIT"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -3367,9 +3548,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -3443,7 +3628,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3482,13 +3666,24 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3501,6 +3696,19 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3524,15 +3732,16 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -3547,7 +3756,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -3650,11 +3859,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3703,6 +3913,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3719,9 +3930,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3741,6 +3953,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -3880,7 +4104,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3904,6 +4127,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-callable": {
@@ -3945,7 +4181,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3985,7 +4221,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3997,7 +4233,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4134,6 +4370,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
       "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.0.6",
         "import-local": "^3.0.2",
@@ -5090,8 +5327,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -5173,7 +5409,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -5214,7 +5449,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5348,7 +5582,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5395,6 +5628,15 @@
         "tmpl": "1.0.x"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5410,6 +5652,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -5421,6 +5672,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -5455,7 +5718,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5563,8 +5825,7 @@
     "node_modules/node-releases": {
       "version": "1.1.73",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
-      "dev": true
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
     },
     "node_modules/node-vault": {
       "version": "0.10.2",
@@ -5584,7 +5845,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5621,6 +5882,18 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -5751,7 +6024,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5813,12 +6085,21 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pirates": {
@@ -6068,6 +6349,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -6237,7 +6531,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6267,6 +6560,78 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6529,6 +6894,44 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
+    "node_modules/superagent": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
+      "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": ">= 7.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6698,7 +7101,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -6707,7 +7109,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -6780,6 +7182,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.1.0.tgz",
       "integrity": "sha512-6szn3+J9WyG2hE+5W8e0ruZrzyk1uFLYye6IGMBadnOzDh8aP7t8CbFpsfCiEx2+wMixAhjFt7lOZC4+l+WbEA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
@@ -6898,6 +7301,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7221,8 +7625,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.2.2",
@@ -7270,6 +7673,53 @@
     }
   },
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.6.tgz",
+      "integrity": "sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==",
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.6.0",
+        "commander": "^6.2.0",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        },
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -7282,14 +7732,13 @@
     "@babel/compat-data": {
       "version": "7.14.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
-      "dev": true
+      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
     },
     "@babel/core": {
       "version": "7.14.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
       "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
@@ -7312,7 +7761,6 @@
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
           "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.14.5"
           }
@@ -7320,14 +7768,12 @@
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -7335,7 +7781,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
       "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -7347,7 +7792,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
       "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
@@ -7358,22 +7802,19 @@
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
     "@babel/helper-environment-visitor": {
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
     },
     "@babel/helper-function-name": {
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.22.15",
         "@babel/types": "^7.23.0"
@@ -7383,7 +7824,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
       }
@@ -7392,7 +7832,6 @@
       "version": "7.14.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
       "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -7401,7 +7840,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
       "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -7410,7 +7848,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
       "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.14.5",
         "@babel/helper-replace-supers": "^7.14.5",
@@ -7426,7 +7863,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
       "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -7441,7 +7877,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
       "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.14.5",
         "@babel/helper-optimise-call-expression": "^7.14.5",
@@ -7453,7 +7888,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
       "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -7462,7 +7896,6 @@
       "version": "7.22.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
       }
@@ -7470,26 +7903,22 @@
     "@babel/helper-string-parser": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
-      "dev": true
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
-      "dev": true
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
     },
     "@babel/helpers": {
       "version": "7.14.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
       "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.5",
@@ -7500,7 +7929,6 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
       "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -7511,7 +7939,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -7520,7 +7947,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -7531,7 +7957,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -7539,26 +7964,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7568,8 +7989,7 @@
     "@babel/parser": {
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-      "dev": true
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -7692,7 +8112,6 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.22.13",
         "@babel/parser": "^7.22.15",
@@ -7703,7 +8122,6 @@
           "version": "7.22.13",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
           "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.22.13",
             "chalk": "^2.4.2"
@@ -7713,7 +8131,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -7722,7 +8139,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -7733,7 +8149,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -7741,26 +8156,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7771,7 +8182,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
       "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
@@ -7789,7 +8199,6 @@
           "version": "7.22.13",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
           "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.22.13",
             "chalk": "^2.4.2"
@@ -7799,7 +8208,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -7808,7 +8216,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -7819,7 +8226,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -7827,32 +8233,27 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7863,7 +8264,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
       "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
-      "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -8191,7 +8591,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -8201,26 +8600,22 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-      "dev": true,
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -8230,6 +8625,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
+    },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8520,7 +8921,8 @@
     "@types/node": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.2.tgz",
-      "integrity": "sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw=="
+      "integrity": "sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw==",
+      "peer": true
     },
     "@types/prettier": {
       "version": "2.3.2",
@@ -8582,6 +8984,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
       "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "4.28.3",
         "@typescript-eslint/scope-manager": "4.28.3",
@@ -8611,6 +9014,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
       "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "4.28.3",
         "@typescript-eslint/types": "4.28.3",
@@ -8677,7 +9081,8 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -8721,6 +9126,15 @@
         "uri-js": "^4.2.2"
       }
     },
+    "akeyless": {
+      "version": "5.0.25",
+      "resolved": "https://registry.npmjs.org/akeyless/-/akeyless-5.0.25.tgz",
+      "integrity": "sha512-R0PFcOyvNSx2khvSZRIg4Hastbg1GWSj+/MwvbUKQVmWpJ9H2onJe6qwe6fkPHAqLdbiFD5ms7k7x6pkWhU/TQ==",
+      "requires": {
+        "@babel/cli": "^7.0.0",
+        "superagent": "^5.3.0"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -8761,7 +9175,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -8936,8 +9350,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -8957,11 +9370,16 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
     },
+    "binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "optional": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -8971,7 +9389,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -8994,7 +9412,6 @@
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
       "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
@@ -9051,6 +9468,24 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -9066,8 +9501,7 @@
     "caniuse-lite": {
       "version": "1.0.30001245",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-      "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
-      "dev": true
+      "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -9088,6 +9522,22 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "optional": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "ci-info": {
       "version": "3.2.0",
@@ -9140,8 +9590,7 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -9156,20 +9605,28 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
       "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA=="
     },
+    "component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -9330,6 +9787,16 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexify": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
@@ -9361,8 +9828,7 @@
     "electron-to-chromium": {
       "version": "1.3.775",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.775.tgz",
-      "integrity": "sha512-EGuiJW4yBPOTj2NtWGZcX93ZE8IGj33HJAx4d3ouE2zOfW2trbWU+t1e0yzLr1qQIw81++txbM3BH52QwSRE6Q==",
-      "dev": true
+      "integrity": "sha512-EGuiJW4yBPOTj2NtWGZcX93ZE8IGj33HJAx4d3ouE2zOfW2trbWU+t1e0yzLr1qQIw81++txbM3BH52QwSRE6Q=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -9390,6 +9856,24 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
       }
     },
     "escalade": {
@@ -9468,6 +9952,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
       "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
@@ -9736,6 +10221,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "fastq": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
@@ -9767,7 +10257,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -9829,30 +10319,37 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ=="
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -9908,8 +10405,7 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "genversion": {
       "version": "3.1.1",
@@ -9935,13 +10431,20 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       }
     },
     "get-package-type": {
@@ -9949,6 +10452,15 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -9965,15 +10477,14 @@
       }
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -9982,7 +10493,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -10058,12 +10569,9 @@
       }
     },
     "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
     "graceful-fs": {
       "version": "4.2.6",
@@ -10098,6 +10606,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -10108,9 +10617,9 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -10118,6 +10627,14 @@
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "html-encoding-sniffer": {
@@ -10221,7 +10738,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10239,6 +10755,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "optional": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-callable": {
@@ -10268,7 +10793,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "devOptional": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -10293,7 +10818,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -10302,7 +10827,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "devOptional": true
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -10411,6 +10936,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
       "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jest/core": "^27.0.6",
         "import-local": "^3.0.2",
@@ -11143,8 +11669,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -11207,8 +11732,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-bigint": {
       "version": "1.0.0",
@@ -11242,8 +11766,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsprim": {
       "version": "2.0.2",
@@ -11356,7 +11879,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -11393,6 +11915,11 @@
         "tmpl": "1.0.x"
       }
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11405,6 +11932,11 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -11414,6 +11946,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
+    },
+    "mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
     },
     "mime-db": {
       "version": "1.52.0",
@@ -11438,7 +11975,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11522,8 +12058,7 @@
     "node-releases": {
       "version": "1.1.73",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
-      "dev": true
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
     },
     "node-vault": {
       "version": "0.10.2",
@@ -11540,7 +12075,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "devOptional": true
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -11566,6 +12101,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+    },
+    "object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
     },
     "once": {
       "version": "1.4.0",
@@ -11661,8 +12201,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -11714,7 +12253,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
+      "devOptional": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "pirates": {
       "version": "4.0.1",
@@ -11901,6 +12445,15 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "optional": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -12018,7 +12571,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -12037,6 +12589,50 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -12238,6 +12834,34 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
+    "superagent": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
+      "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.15.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+          "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+          "requires": {
+            "side-channel": "^1.1.0"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12372,14 +12996,13 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -12433,6 +13056,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.1.0.tgz",
       "integrity": "sha512-6szn3+J9WyG2hE+5W8e0ruZrzyk1uFLYye6IGMBadnOzDh8aP7t8CbFpsfCiEx2+wMixAhjFt7lOZC4+l+WbEA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
@@ -12505,7 +13129,8 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -12758,8 +13383,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "secrets",
     "cloud",
     "aws",
-    "hashicorp"
+    "hashicorp",
+    "akeyless"
   ],
   "engines": {
     "node": ">=16"
@@ -69,6 +70,7 @@
   "dependencies": {
     "@google-cloud/secret-manager": "^5.3.0",
     "@types/flat": "^5.0.2",
+    "akeyless": "^5.0.25",
     "aws-sdk": "^2.1002.0",
     "chalk": "^4.1.2",
     "commander": "^8.2.0",

--- a/src/SecretsFoundry.ts
+++ b/src/SecretsFoundry.ts
@@ -7,7 +7,7 @@ import { flatten } from 'flat';
 import Utils, { DELIMITER, UnresolvedSecretError } from './utils';
 
 export class SecretsFoundry {
-  EXPAND_REGEX = /\${([:a-zA-Z0-9_;(=),\\.\->/]+)?}/g;
+  EXPAND_REGEX = /\${([:a-zA-Z0-9_|;(=),\\.\->/]+)?}/g;
   CONST_NOT_FOUND = 'value_not_found';
   private loaders: Loader[];
 

--- a/src/loaders/AkeylessLoader.ts
+++ b/src/loaders/AkeylessLoader.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import Loader from './loader';
 
 /** Lazy require so importing `Loaders` does not load the SDK (Jest / tree-shaking friendly). */
@@ -73,6 +74,11 @@ const splitPipeList = function (raw: string | undefined): string[] | undefined {
   return parts.length ? parts : undefined;
 };
 
+/** SHA-256 hex for cache keys — avoids keeping raw secrets in fingerprint strings. */
+const sha256Hex = function (value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+};
+
 /** Default access-key session length if /auth omits expiration (typical token ~15m). */
 const ACCESS_KEY_DEFAULT_TTL_MS = 14 * 60 * 1000;
 
@@ -140,7 +146,9 @@ type CachedAkeylessSession = {
  *
  * Session: one loader instance (as registered in `Loaders`) reuses the same `V2Api`
  * client and token until expiry or until gateway / credentials (fingerprint) change,
- * so resolving many secrets does not repeat `/auth` for each variable.
+ * so resolving many secrets does not repeat `/auth` for each variable. Session
+ * fingerprints use SHA-256 hashes of secret material (token or access id+key),
+ * not raw credentials in strings.
  */
 export default class AkeylessLoader extends Loader {
   private cachedSession: CachedAkeylessSession | null = null;
@@ -184,11 +192,11 @@ since the client is supposed to be calling canResolve first'
   private sessionFingerprint(gateway: string): string {
     const t = process.env.AKEYLESS_TOKEN?.trim();
     if (t) {
-      return `token:${gateway}:${t}`;
+      return `token:${gateway}:${sha256Hex(t)}`;
     }
     const accessId = process.env.AKEYLESS_ACCESS_ID?.trim() ?? '';
     const accessKey = process.env.AKEYLESS_ACCESS_KEY?.trim() ?? '';
-    return `access_key:${gateway}:${accessId}:${accessKey}`;
+    return `access_key:${gateway}:${sha256Hex(`${accessId}\0${accessKey}`)}`;
   }
 
   private async resolveTokenAndApi(args: AkeylessArgs): Promise<{

--- a/src/loaders/AkeylessLoader.ts
+++ b/src/loaders/AkeylessLoader.ts
@@ -38,64 +38,112 @@ const pickSecretFromResponse = function (
   ];
   for (const key of candidates) {
     if (Object.prototype.hasOwnProperty.call(data, key)) {
-      const s = stringifySecretValue(data[key]);
-      if (s !== '') {
-        return s;
-      }
-    }
-  }
-  for (const value of Object.values(data)) {
-    const s = stringifySecretValue(value);
-    if (s.trim() !== '') {
-      return s;
+      // Return the value for this key even when empty — do not fall through to
+      // another key (avoids returning an unrelated secret from the same payload).
+      return stringifySecretValue(data[key]);
     }
   }
   throw new Error(`No value for "${requestedPath}" in Akeyless response`);
 };
 
+/** Dynamic / rotated APIs return a JSON object; stringify for interpolation (same idea as the Buildkite plugin). */
+const formatStructuredResponse = function (data: unknown): string {
+  if (data === null || data === undefined) {
+    throw new Error('Akeyless returned an empty response');
+  }
+  if (typeof data === 'string') {
+    return data;
+  }
+  return JSON.stringify(data);
+};
+
+const getGatewayUrl = function (args: Record<string, string | undefined>): string {
+  return (
+    args.gateway ||
+    process.env.AKEYLESS_GATEWAY_URL?.trim() ||
+    'https://api.akeyless.io'
+  ).replace(/\/$/, '');
+};
+
+const splitPipeList = function (raw: string | undefined): string[] | undefined {
+  if (raw === undefined || raw.trim() === '') {
+    return undefined;
+  }
+  const parts = raw.split('|').map((s) => s.trim()).filter(Boolean);
+  return parts.length ? parts : undefined;
+};
+
+type AkeylessArgs = Record<string, string | undefined>;
+
 /**
- * AkeylessLoader loads a static secret from Akeyless via the public API or a Gateway.
- * Pattern: akeyless(optionalArgs):/path/to/static-secret
+ * Akeyless loaders for static, dynamic, and rotated secrets.
  *
- * Environment:
+ * Prefixes (underscores match `${...}` expansion rules in SecretsFoundry):
+ * - `akeyless(optionalArgs):/path` — static secret (`get-secret-value`)
+ * - `akeyless_dynamic(optionalArgs):/path` — dynamic secret (`get-dynamic-secret-value`)
+ * - `akeyless_rotated(optionalArgs):/path` — rotated secret (`get-rotated-secret-value`)
+ *
+ * Environment (all kinds):
  * - AKEYLESS_GATEWAY_URL — API / Gateway base URL (default: https://api.akeyless.io)
- * - AKEYLESS_TOKEN — optional; if set, used instead of access-key auth
+ * - AKEYLESS_TOKEN — optional; if set, skips access-key auth
  * - AKEYLESS_ACCESS_ID and AKEYLESS_ACCESS_KEY — access_key auth when no token
  *
- * Optional loader args (comma-separated key=value), override env where noted:
- * - gateway — same as AKEYLESS_GATEWAY_URL
- * - ignore-cache — passed to get-secret-value (true/false)
- * - json — request JSON-shaped payload from API (true/false)
- * - version — secret version (number)
+ * Optional args (comma-separated key=value):
+ * - gateway — overrides AKEYLESS_GATEWAY_URL
+ *
+ * Static-only args: ignore-cache, json, version
+ *
+ * Dynamic-only args: timeout, args (pipe-separated entries, e.g. `args=--k=v|--x=y`), host, dbname, target, json
+ * Env fallback: AKEYLESS_DYNAMIC_TIMEOUT, AKEYLESS_DYNAMIC_ARGS (pipe-separated)
+ *
+ * Rotated-only args: host (or AKEYLESS_ROTATED_SECRET_HOST), ignore-cache, json, version
  */
 export default class AkeylessLoader extends Loader {
-  private static PATTERN =
-    /^akeyless(\(([:a-zA-Z0-9_;(=),\\.\-/]*)?\))?:([a-zA-Z0-9_.\-/]+)$/;
+  private static STATIC_PATTERN =
+    /^akeyless(\(([:a-zA-Z0-9_|;(=),\\.\-/]*)?\))?:([a-zA-Z0-9_.\-/]+)$/;
+
+  private static DYNAMIC_PATTERN =
+    /^akeyless_dynamic(\(([:a-zA-Z0-9_|;(=),\\.\-/]*)?\))?:([a-zA-Z0-9_.\-/]+)$/;
+
+  private static ROTATED_PATTERN =
+    /^akeyless_rotated(\(([:a-zA-Z0-9_|;(=),\\.\-/]*)?\))?:([a-zA-Z0-9_.\-/]+)$/;
 
   public canResolve(value: string): boolean {
-    return value.match(AkeylessLoader.PATTERN) !== null;
+    return (
+      value.match(AkeylessLoader.STATIC_PATTERN) !== null ||
+      value.match(AkeylessLoader.DYNAMIC_PATTERN) !== null ||
+      value.match(AkeylessLoader.ROTATED_PATTERN) !== null
+    );
   }
 
   public async resolve(variable: string): Promise<string> {
-    const groups = variable.match(AkeylessLoader.PATTERN);
-    if (groups === null) {
-      throw new Error(
-        'AkeylessLoader cannot parse the variable name. This should never happen \
-since the client is supposed to be calling canResolve first'
-      );
+    const dynamic = variable.match(AkeylessLoader.DYNAMIC_PATTERN);
+    if (dynamic) {
+      return this.resolveDynamic(dynamic[2], dynamic[3]);
     }
-    const args = this.getArgsFromStr(groups[2]);
-    const secretPath = groups[3];
+    const rotated = variable.match(AkeylessLoader.ROTATED_PATTERN);
+    if (rotated) {
+      return this.resolveRotated(rotated[2], rotated[3]);
+    }
+    const stat = variable.match(AkeylessLoader.STATIC_PATTERN);
+    if (stat) {
+      return this.resolveStatic(stat[2], stat[3]);
+    }
+    throw new Error(
+      'AkeylessLoader cannot parse the variable name. This should never happen \
+since the client is supposed to be calling canResolve first'
+    );
+  }
 
-    const gateway =
-      args.gateway ||
-      process.env.AKEYLESS_GATEWAY_URL?.trim() ||
-      'https://api.akeyless.io';
-
-    const akeyless = loadAkeyless();
-    const client = new akeyless.ApiClient();
-    client.basePath = gateway.replace(/\/$/, '');
-    const api = new akeyless.V2Api(client);
+  private async resolveTokenAndApi(args: AkeylessArgs): Promise<{
+    api: import('akeyless').V2Api;
+    token: string;
+    sdk: typeof import('akeyless');
+  }> {
+    const sdk = loadAkeyless();
+    const client = new sdk.ApiClient();
+    client.basePath = getGatewayUrl(args);
+    const api = new sdk.V2Api(client);
 
     let token = process.env.AKEYLESS_TOKEN?.trim();
     if (!token) {
@@ -106,7 +154,7 @@ since the client is supposed to be calling canResolve first'
           'Akeyless auth is not configured: set AKEYLESS_TOKEN, or both AKEYLESS_ACCESS_ID and AKEYLESS_ACCESS_KEY'
         );
       }
-      const authBody = akeyless.Auth.constructFromObject({
+      const authBody = sdk.Auth.constructFromObject({
         'access-id': accessId,
         'access-key': accessKey,
         'access-type': 'access_key',
@@ -117,6 +165,15 @@ since the client is supposed to be calling canResolve first'
         throw new Error('Akeyless authentication did not return a token');
       }
     }
+    return { api, token, sdk };
+  }
+
+  private async resolveStatic(
+    argsStr: string | undefined,
+    secretPath: string
+  ): Promise<string> {
+    const args = this.getArgsFromStr(argsStr ?? '');
+    const { api, token, sdk } = await this.resolveTokenAndApi(args);
 
     const getBody: Record<string, unknown> = {
       names: [secretPath],
@@ -137,11 +194,98 @@ since the client is supposed to be calling canResolve first'
       getBody.version = n;
     }
 
-    const payload = akeyless.GetSecretValue.constructFromObject(getBody);
+    const payload = sdk.GetSecretValue.constructFromObject(getBody);
     const raw = (await api.getSecretValue(payload)) as Record<
       string,
       unknown
     >;
     return pickSecretFromResponse(secretPath, raw);
+  }
+
+  private async resolveDynamic(
+    argsStr: string | undefined,
+    secretName: string
+  ): Promise<string> {
+    const args = this.getArgsFromStr(argsStr ?? '');
+    const { api, token, sdk } = await this.resolveTokenAndApi(args);
+
+    const body: Record<string, unknown> = {
+      name: secretName,
+      token,
+    };
+
+    const timeoutStr =
+      args.timeout || process.env.AKEYLESS_DYNAMIC_TIMEOUT?.trim();
+    if (timeoutStr !== undefined) {
+      const n = Number(timeoutStr);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new Error(
+          'Akeyless dynamic loader "timeout" must be a non-negative number'
+        );
+      }
+      body.timeout = n;
+    }
+
+    const argList =
+      splitPipeList(args.args) ||
+      splitPipeList(process.env.AKEYLESS_DYNAMIC_ARGS);
+    if (argList) {
+      body.args = argList;
+    }
+    if (args.host) {
+      body.host = args.host;
+    }
+    if (args.dbname) {
+      body.dbname = args.dbname;
+    }
+    if (args.target) {
+      body.target = args.target;
+    }
+    if (args.json === 'true') {
+      body.json = true;
+    }
+
+    const payload = sdk.GetDynamicSecretValue.constructFromObject(body);
+    const raw = await api.getDynamicSecretValue(payload);
+    return formatStructuredResponse(raw);
+  }
+
+  private async resolveRotated(
+    argsStr: string | undefined,
+    secretPath: string
+  ): Promise<string> {
+    const args = this.getArgsFromStr(argsStr ?? '');
+    const { api, token, sdk } = await this.resolveTokenAndApi(args);
+
+    const body: Record<string, unknown> = {
+      names: secretPath,
+      token,
+    };
+
+    const host =
+      args.host || process.env.AKEYLESS_ROTATED_SECRET_HOST?.trim();
+    if (host) {
+      body.host = host;
+    }
+    if (args['ignore-cache'] !== undefined) {
+      body['ignore-cache'] =
+        args['ignore-cache'] === 'true' ? 'true' : 'false';
+    }
+    if (args.json === 'true') {
+      body.json = true;
+    }
+    if (args.version !== undefined) {
+      const n = Number(args.version);
+      if (!Number.isFinite(n)) {
+        throw new Error(
+          'Akeyless rotated loader "version" argument must be a number'
+        );
+      }
+      body.version = n;
+    }
+
+    const payload = sdk.GetRotatedSecretValue.constructFromObject(body);
+    const raw = await api.getRotatedSecretValue(payload);
+    return formatStructuredResponse(raw);
   }
 }

--- a/src/loaders/AkeylessLoader.ts
+++ b/src/loaders/AkeylessLoader.ts
@@ -1,0 +1,147 @@
+import Loader from './loader';
+
+/** Lazy require so importing `Loaders` does not load the SDK (Jest / tree-shaking friendly). */
+const loadAkeyless = function (): typeof import('akeyless') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('akeyless');
+};
+
+const normalizePath = function (p: string): string {
+  return p.startsWith('/') ? p : `/${p}`;
+};
+
+const stringifySecretValue = function (value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+};
+
+const pickSecretFromResponse = function (
+  requestedPath: string,
+  data: Record<string, unknown> | null | undefined
+): string {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Akeyless returned an empty secret payload');
+  }
+  const trimmed = requestedPath.trim();
+  const candidates = [
+    trimmed,
+    normalizePath(trimmed),
+    trimmed.replace(/^\//, ''),
+  ];
+  for (const key of candidates) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
+      const s = stringifySecretValue(data[key]);
+      if (s !== '') {
+        return s;
+      }
+    }
+  }
+  for (const value of Object.values(data)) {
+    const s = stringifySecretValue(value);
+    if (s.trim() !== '') {
+      return s;
+    }
+  }
+  throw new Error(`No value for "${requestedPath}" in Akeyless response`);
+};
+
+/**
+ * AkeylessLoader loads a static secret from Akeyless via the public API or a Gateway.
+ * Pattern: akeyless(optionalArgs):/path/to/static-secret
+ *
+ * Environment:
+ * - AKEYLESS_GATEWAY_URL — API / Gateway base URL (default: https://api.akeyless.io)
+ * - AKEYLESS_TOKEN — optional; if set, used instead of access-key auth
+ * - AKEYLESS_ACCESS_ID and AKEYLESS_ACCESS_KEY — access_key auth when no token
+ *
+ * Optional loader args (comma-separated key=value), override env where noted:
+ * - gateway — same as AKEYLESS_GATEWAY_URL
+ * - ignore-cache — passed to get-secret-value (true/false)
+ * - json — request JSON-shaped payload from API (true/false)
+ * - version — secret version (number)
+ */
+export default class AkeylessLoader extends Loader {
+  private static PATTERN =
+    /^akeyless(\(([:a-zA-Z0-9_;(=),\\.\-/]*)?\))?:([a-zA-Z0-9_.\-/]+)$/;
+
+  public canResolve(value: string): boolean {
+    return value.match(AkeylessLoader.PATTERN) !== null;
+  }
+
+  public async resolve(variable: string): Promise<string> {
+    const groups = variable.match(AkeylessLoader.PATTERN);
+    if (groups === null) {
+      throw new Error(
+        'AkeylessLoader cannot parse the variable name. This should never happen \
+since the client is supposed to be calling canResolve first'
+      );
+    }
+    const args = this.getArgsFromStr(groups[2]);
+    const secretPath = groups[3];
+
+    const gateway =
+      args.gateway ||
+      process.env.AKEYLESS_GATEWAY_URL?.trim() ||
+      'https://api.akeyless.io';
+
+    const akeyless = loadAkeyless();
+    const client = new akeyless.ApiClient();
+    client.basePath = gateway.replace(/\/$/, '');
+    const api = new akeyless.V2Api(client);
+
+    let token = process.env.AKEYLESS_TOKEN?.trim();
+    if (!token) {
+      const accessId = process.env.AKEYLESS_ACCESS_ID?.trim();
+      const accessKey = process.env.AKEYLESS_ACCESS_KEY?.trim();
+      if (!accessId || !accessKey) {
+        throw new Error(
+          'Akeyless auth is not configured: set AKEYLESS_TOKEN, or both AKEYLESS_ACCESS_ID and AKEYLESS_ACCESS_KEY'
+        );
+      }
+      const authBody = akeyless.Auth.constructFromObject({
+        'access-id': accessId,
+        'access-key': accessKey,
+        'access-type': 'access_key',
+      });
+      const authOut = await api.auth(authBody);
+      token = authOut?.token?.trim();
+      if (!token) {
+        throw new Error('Akeyless authentication did not return a token');
+      }
+    }
+
+    const getBody: Record<string, unknown> = {
+      names: [secretPath],
+      token,
+    };
+    if (args['ignore-cache'] !== undefined) {
+      getBody['ignore-cache'] =
+        args['ignore-cache'] === 'true' ? 'true' : 'false';
+    }
+    if (args.json === 'true') {
+      getBody.json = true;
+    }
+    if (args.version !== undefined) {
+      const n = Number(args.version);
+      if (!Number.isFinite(n)) {
+        throw new Error('Akeyless loader "version" argument must be a number');
+      }
+      getBody.version = n;
+    }
+
+    const payload = akeyless.GetSecretValue.constructFromObject(getBody);
+    const raw = (await api.getSecretValue(payload)) as Record<
+      string,
+      unknown
+    >;
+    return pickSecretFromResponse(secretPath, raw);
+  }
+}

--- a/src/loaders/AkeylessLoader.ts
+++ b/src/loaders/AkeylessLoader.ts
@@ -73,7 +73,47 @@ const splitPipeList = function (raw: string | undefined): string[] | undefined {
   return parts.length ? parts : undefined;
 };
 
+/** Default access-key session length if /auth omits expiration (typical token ~15m). */
+const ACCESS_KEY_DEFAULT_TTL_MS = 14 * 60 * 1000;
+
+/** Pre-baked token cache window (no server hint). */
+const ENV_TOKEN_TTL_MS = 50 * 60 * 1000;
+
+/** Refresh slightly before expiry to avoid edge failures. */
+const EXPIRY_MARGIN_MS = 60 * 1000;
+
+const expiryFromAuthOutput = function (authOut: {
+  expiration?: string;
+}): number {
+  const exp = authOut?.expiration?.trim();
+  const now = Date.now();
+  if (!exp) {
+    return now + ACCESS_KEY_DEFAULT_TTL_MS;
+  }
+  const asNum = Number(exp);
+  if (Number.isFinite(asNum) && asNum > 1e12) {
+    return asNum;
+  }
+  if (Number.isFinite(asNum) && asNum > 1e9) {
+    return asNum * 1000;
+  }
+  const parsed = Date.parse(exp);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+  return now + ACCESS_KEY_DEFAULT_TTL_MS;
+};
+
 type AkeylessArgs = Record<string, string | undefined>;
+
+type CachedAkeylessSession = {
+  fingerprint: string;
+  gateway: string;
+  api: import('akeyless').V2Api;
+  sdk: typeof import('akeyless');
+  token: string;
+  expiresAtMs: number;
+};
 
 /**
  * Akeyless loaders for static, dynamic, and rotated secrets.
@@ -97,8 +137,14 @@ type AkeylessArgs = Record<string, string | undefined>;
  * Env fallback: AKEYLESS_DYNAMIC_TIMEOUT, AKEYLESS_DYNAMIC_ARGS (pipe-separated)
  *
  * Rotated-only args: host (or AKEYLESS_ROTATED_SECRET_HOST), ignore-cache, json, version
+ *
+ * Session: one loader instance (as registered in `Loaders`) reuses the same `V2Api`
+ * client and token until expiry or until gateway / credentials (fingerprint) change,
+ * so resolving many secrets does not repeat `/auth` for each variable.
  */
 export default class AkeylessLoader extends Loader {
+  private cachedSession: CachedAkeylessSession | null = null;
+
   private static STATIC_PATTERN =
     /^akeyless(\(([:a-zA-Z0-9_|;(=),\\.\-/]*)?\))?:([a-zA-Z0-9_.\-/]+)$/;
 
@@ -135,18 +181,47 @@ since the client is supposed to be calling canResolve first'
     );
   }
 
+  private sessionFingerprint(gateway: string): string {
+    const t = process.env.AKEYLESS_TOKEN?.trim();
+    if (t) {
+      return `token:${gateway}:${t}`;
+    }
+    const accessId = process.env.AKEYLESS_ACCESS_ID?.trim() ?? '';
+    const accessKey = process.env.AKEYLESS_ACCESS_KEY?.trim() ?? '';
+    return `access_key:${gateway}:${accessId}:${accessKey}`;
+  }
+
   private async resolveTokenAndApi(args: AkeylessArgs): Promise<{
     api: import('akeyless').V2Api;
     token: string;
     sdk: typeof import('akeyless');
   }> {
+    const gateway = getGatewayUrl(args);
+    const fingerprint = this.sessionFingerprint(gateway);
+    const now = Date.now();
+    if (
+      this.cachedSession &&
+      this.cachedSession.fingerprint === fingerprint &&
+      this.cachedSession.gateway === gateway &&
+      now < this.cachedSession.expiresAtMs
+    ) {
+      return {
+        api: this.cachedSession.api,
+        token: this.cachedSession.token,
+        sdk: this.cachedSession.sdk,
+      };
+    }
+
     const sdk = loadAkeyless();
     const client = new sdk.ApiClient();
-    client.basePath = getGatewayUrl(args);
+    client.basePath = gateway;
     const api = new sdk.V2Api(client);
 
     let token = process.env.AKEYLESS_TOKEN?.trim();
-    if (!token) {
+    let expiresAtMs: number;
+    if (token) {
+      expiresAtMs = now + ENV_TOKEN_TTL_MS;
+    } else {
       const accessId = process.env.AKEYLESS_ACCESS_ID?.trim();
       const accessKey = process.env.AKEYLESS_ACCESS_KEY?.trim();
       if (!accessId || !accessKey) {
@@ -164,7 +239,20 @@ since the client is supposed to be calling canResolve first'
       if (!token) {
         throw new Error('Akeyless authentication did not return a token');
       }
+      expiresAtMs = expiryFromAuthOutput(authOut) - EXPIRY_MARGIN_MS;
+      if (expiresAtMs <= now) {
+        expiresAtMs = now + ACCESS_KEY_DEFAULT_TTL_MS;
+      }
     }
+
+    this.cachedSession = {
+      fingerprint,
+      gateway,
+      api,
+      sdk,
+      token,
+      expiresAtMs,
+    };
     return { api, token, sdk };
   }
 

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -4,11 +4,13 @@ import AwsSecretsLoader from './AwsSecretsLoader';
 import AwsSSMLoader from './AwsSSMLoader';
 import VaultLoader from './VaultLoader';
 import GoogleSecretsLoader from './GoogleSecretsLoader';
+import AkeylessLoader from './AkeylessLoader';
 
 export const Loaders: Loader[] = [
   new AwsS3Loader(),
   new AwsSecretsLoader(),
   new AwsSSMLoader(),
   new VaultLoader(),
-  new GoogleSecretsLoader()
+  new GoogleSecretsLoader(),
+  new AkeylessLoader(),
 ];

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,3 +1,4 @@
+import '../slowBufferShim';
 import Loader from './loader';
 import AwsS3Loader from './AwsS3Loader';
 import AwsSecretsLoader from './AwsSecretsLoader';

--- a/src/loaders/loader.ts
+++ b/src/loaders/loader.ts
@@ -21,8 +21,13 @@ export default abstract class Loader {
     if (argsStr) {
       const args = argsStr.trim().split(',');
       for (const arg of args) {
-        const keyValue = arg.trim().split('=');
-        argsMap[keyValue[0]] = keyValue[1];
+        const trimmed = arg.trim();
+        const eq = trimmed.indexOf('=');
+        if (eq === -1) {
+          argsMap[trimmed] = undefined as unknown as string;
+        } else {
+          argsMap[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
+        }
       }
     }
     return argsMap;

--- a/src/slowBufferShim.ts
+++ b/src/slowBufferShim.ts
@@ -1,0 +1,20 @@
+/**
+ * Node 21+ removed `SlowBuffer`. Legacy deps (e.g. `jwa` via `akeyless`) read
+ * `SlowBuffer.prototype` at load time. Import this module before any code that
+ * may transitively `require('jwa')` (CLI, tests, or `Loaders`).
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const buffer = require('buffer') as {
+  Buffer: typeof Buffer;
+  SlowBuffer?: typeof Buffer;
+};
+if (buffer.SlowBuffer == null && buffer.Buffer != null) {
+  Object.defineProperty(buffer, 'SlowBuffer', {
+    value: buffer.Buffer,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+}
+
+export {};

--- a/src/types/akeyless.d.ts
+++ b/src/types/akeyless.d.ts
@@ -1,0 +1,19 @@
+declare module 'akeyless' {
+  export class ApiClient {
+    basePath: string;
+  }
+
+  export class V2Api {
+    constructor(client: ApiClient);
+    auth(body: unknown): Promise<{ token?: string }>;
+    getSecretValue(body: unknown): Promise<Record<string, unknown>>;
+  }
+
+  export const Auth: {
+    constructFromObject(data: Record<string, unknown>): unknown;
+  };
+
+  export const GetSecretValue: {
+    constructFromObject(data: Record<string, unknown>): unknown;
+  };
+}

--- a/src/types/akeyless.d.ts
+++ b/src/types/akeyless.d.ts
@@ -5,7 +5,7 @@ declare module 'akeyless' {
 
   export class V2Api {
     constructor(client: ApiClient);
-    auth(body: unknown): Promise<{ token?: string }>;
+    auth(body: unknown): Promise<{ token?: string; expiration?: string }>;
     getSecretValue(body: unknown): Promise<Record<string, unknown>>;
     getDynamicSecretValue(body: unknown): Promise<unknown>;
     getRotatedSecretValue(body: unknown): Promise<unknown>;

--- a/src/types/akeyless.d.ts
+++ b/src/types/akeyless.d.ts
@@ -7,6 +7,8 @@ declare module 'akeyless' {
     constructor(client: ApiClient);
     auth(body: unknown): Promise<{ token?: string }>;
     getSecretValue(body: unknown): Promise<Record<string, unknown>>;
+    getDynamicSecretValue(body: unknown): Promise<unknown>;
+    getRotatedSecretValue(body: unknown): Promise<unknown>;
   }
 
   export const Auth: {
@@ -14,6 +16,14 @@ declare module 'akeyless' {
   };
 
   export const GetSecretValue: {
+    constructFromObject(data: Record<string, unknown>): unknown;
+  };
+
+  export const GetDynamicSecretValue: {
+    constructFromObject(data: Record<string, unknown>): unknown;
+  };
+
+  export const GetRotatedSecretValue: {
     constructFromObject(data: Record<string, unknown>): unknown;
   };
 }

--- a/tests/loaders/AkeylessLoader.test.ts
+++ b/tests/loaders/AkeylessLoader.test.ts
@@ -2,17 +2,27 @@ import AkeylessLoader from '../../src/loaders/AkeylessLoader';
 
 const mockAuth = jest.fn();
 const mockGetSecretValue = jest.fn();
+const mockGetDynamicSecretValue = jest.fn();
+const mockGetRotatedSecretValue = jest.fn();
 
 jest.mock('akeyless', () => ({
   ApiClient: jest.fn().mockImplementation(() => ({ basePath: '' })),
   V2Api: jest.fn().mockImplementation(() => ({
     auth: mockAuth,
     getSecretValue: mockGetSecretValue,
+    getDynamicSecretValue: mockGetDynamicSecretValue,
+    getRotatedSecretValue: mockGetRotatedSecretValue,
   })),
   Auth: {
     constructFromObject: (data: Record<string, unknown>) => data,
   },
   GetSecretValue: {
+    constructFromObject: (data: Record<string, unknown>) => data,
+  },
+  GetDynamicSecretValue: {
+    constructFromObject: (data: Record<string, unknown>) => data,
+  },
+  GetRotatedSecretValue: {
     constructFromObject: (data: Record<string, unknown>) => data,
   },
 }));
@@ -25,8 +35,17 @@ describe('AkeylessLoader', () => {
     process.env = { ...OLD_ENV };
     mockAuth.mockReset();
     mockGetSecretValue.mockReset();
+    mockGetDynamicSecretValue.mockReset();
+    mockGetRotatedSecretValue.mockReset();
     mockAuth.mockResolvedValue({ token: 'test-token' });
     mockGetSecretValue.mockResolvedValue({ '/app/db': 'secret-value' });
+    mockGetDynamicSecretValue.mockResolvedValue({
+      password: 'dyn-pass',
+      user: 'dyn-user',
+    });
+    mockGetRotatedSecretValue.mockResolvedValue({
+      value: 'rotated-json',
+    });
   });
 
   afterAll(() => {
@@ -40,6 +59,11 @@ describe('AkeylessLoader', () => {
       'akeyless:app/db',
       'akeyless(gateway=https://gw.example.com:8080/v2):/app/db',
       'akeyless(ignore-cache=true,json=true):/app/db',
+      'akeyless_dynamic:/dyn/db',
+      'akeyless_dynamic(timeout=60):/dyn/db',
+      'akeyless_dynamic(args=a|b):/dyn/db',
+      'akeyless_rotated:/rot/db',
+      'akeyless_rotated(host=my.host):/rot/db',
     ];
     for (const v of valid) {
       expect(loader.canResolve(v)).toBeTruthy();
@@ -53,6 +77,7 @@ describe('AkeylessLoader', () => {
       'akeyless:',
       'akeyless@:/x',
       'akeyless-ssm:/x',
+      'akeyless-dynamic:/x',
       'aws-ssm:/x',
     ];
     for (const v of invalid) {
@@ -126,6 +151,26 @@ describe('AkeylessLoader', () => {
     );
   });
 
+  it('should not return a different key when the requested path is missing', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+    mockGetSecretValue.mockResolvedValueOnce({
+      '/other/secret': 'wrong-one',
+    });
+
+    const loader = new AkeylessLoader();
+    await expect(loader.resolve('akeyless:/wanted/secret')).rejects.toThrow(
+      /No value/
+    );
+  });
+
+  it('should return empty string when the requested key exists with empty value', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+    mockGetSecretValue.mockResolvedValueOnce({ '/app/db': '' });
+
+    const loader = new AkeylessLoader();
+    await expect(loader.resolve('akeyless:/app/db')).resolves.toBe('');
+  });
+
   it('should throw on invalid version argument', async () => {
     process.env.AKEYLESS_TOKEN = 't';
 
@@ -133,5 +178,72 @@ describe('AkeylessLoader', () => {
     await expect(
       loader.resolve('akeyless(version=not-a-number):/app/db')
     ).rejects.toThrow(/version/);
+  });
+
+  it('should resolve dynamic secret as JSON string', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+    mockGetDynamicSecretValue.mockResolvedValueOnce({ p: 1 });
+
+    const loader = new AkeylessLoader();
+    const out = await loader.resolve('akeyless_dynamic(timeout=30):/dyn/x');
+    expect(out).toBe('{"p":1}');
+    expect(mockGetDynamicSecretValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '/dyn/x',
+        token: 't',
+        timeout: 30,
+      })
+    );
+  });
+
+  it('should pass pipe-separated args to dynamic secret', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+
+    const loader = new AkeylessLoader();
+    await loader.resolve(
+      'akeyless_dynamic(args=--k=v|--x=y):/dyn/x'
+    );
+    expect(mockGetDynamicSecretValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: ['--k=v', '--x=y'],
+      })
+    );
+  });
+
+  it('should resolve rotated secret as JSON string', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+
+    const loader = new AkeylessLoader();
+    const out = await loader.resolve(
+      'akeyless_rotated(host=h.example):/rot/item'
+    );
+    expect(out).toBe('{"value":"rotated-json"}');
+    expect(mockGetRotatedSecretValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        names: '/rot/item',
+        token: 't',
+        host: 'h.example',
+      })
+    );
+  });
+
+  it('should use AKEYLESS_ROTATED_SECRET_HOST when arg omitted', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+    process.env.AKEYLESS_ROTATED_SECRET_HOST = 'from-env';
+
+    const loader = new AkeylessLoader();
+    await loader.resolve('akeyless_rotated:/rot/item');
+    expect(mockGetRotatedSecretValue).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'from-env' })
+    );
+  });
+
+  it('should throw on invalid dynamic timeout', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+
+    const loader = new AkeylessLoader();
+    await expect(
+      loader.resolve('akeyless_dynamic(timeout=bad):/x')
+    ).rejects.toThrow(/timeout/);
   });
 });

--- a/tests/loaders/AkeylessLoader.test.ts
+++ b/tests/loaders/AkeylessLoader.test.ts
@@ -1,0 +1,137 @@
+import AkeylessLoader from '../../src/loaders/AkeylessLoader';
+
+const mockAuth = jest.fn();
+const mockGetSecretValue = jest.fn();
+
+jest.mock('akeyless', () => ({
+  ApiClient: jest.fn().mockImplementation(() => ({ basePath: '' })),
+  V2Api: jest.fn().mockImplementation(() => ({
+    auth: mockAuth,
+    getSecretValue: mockGetSecretValue,
+  })),
+  Auth: {
+    constructFromObject: (data: Record<string, unknown>) => data,
+  },
+  GetSecretValue: {
+    constructFromObject: (data: Record<string, unknown>) => data,
+  },
+}));
+
+describe('AkeylessLoader', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    mockAuth.mockReset();
+    mockGetSecretValue.mockReset();
+    mockAuth.mockResolvedValue({ token: 'test-token' });
+    mockGetSecretValue.mockResolvedValue({ '/app/db': 'secret-value' });
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('should return true on canResolve for valid patterns', () => {
+    const loader = new AkeylessLoader();
+    const valid = [
+      'akeyless:/app/db',
+      'akeyless:app/db',
+      'akeyless(gateway=https://gw.example.com:8080/v2):/app/db',
+      'akeyless(ignore-cache=true,json=true):/app/db',
+    ];
+    for (const v of valid) {
+      expect(loader.canResolve(v)).toBeTruthy();
+    }
+  });
+
+  it('should return false on canResolve for invalid patterns', () => {
+    const loader = new AkeylessLoader();
+    const invalid = [
+      '',
+      'akeyless:',
+      'akeyless@:/x',
+      'akeyless-ssm:/x',
+      'aws-ssm:/x',
+    ];
+    for (const v of invalid) {
+      expect(loader.canResolve(v)).not.toBeTruthy();
+    }
+  });
+
+  it('should resolve using AKEYLESS_ACCESS_ID and AKEYLESS_ACCESS_KEY', async () => {
+    process.env.AKEYLESS_ACCESS_ID = 'id';
+    process.env.AKEYLESS_ACCESS_KEY = 'key';
+    delete process.env.AKEYLESS_TOKEN;
+    mockGetSecretValue.mockResolvedValueOnce({ '/app/db': 'from-mock' });
+
+    const loader = new AkeylessLoader();
+    const out = await loader.resolve('akeyless:/app/db');
+    expect(out).toBe('from-mock');
+    expect(mockAuth).toHaveBeenCalledTimes(1);
+    expect(mockGetSecretValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        names: ['/app/db'],
+        token: 'test-token',
+      })
+    );
+  });
+
+  it('should resolve using AKEYLESS_TOKEN without calling auth', async () => {
+    process.env.AKEYLESS_TOKEN = 'pre-baked';
+    delete process.env.AKEYLESS_ACCESS_ID;
+    delete process.env.AKEYLESS_ACCESS_KEY;
+    mockGetSecretValue.mockResolvedValueOnce({ '/app/db': 'tok-val' });
+
+    const loader = new AkeylessLoader();
+    const out = await loader.resolve('akeyless:/app/db');
+    expect(out).toBe('tok-val');
+    expect(mockAuth).not.toHaveBeenCalled();
+    expect(mockGetSecretValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'pre-baked',
+        names: ['/app/db'],
+      })
+    );
+  });
+
+  it('should pick value when response key omits leading slash', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+    mockGetSecretValue.mockResolvedValueOnce({ 'app/db': 'slashless' });
+
+    const loader = new AkeylessLoader();
+    const out = await loader.resolve('akeyless:app/db');
+    expect(out).toBe('slashless');
+  });
+
+  it('should throw when auth is not configured', async () => {
+    delete process.env.AKEYLESS_TOKEN;
+    delete process.env.AKEYLESS_ACCESS_ID;
+    delete process.env.AKEYLESS_ACCESS_KEY;
+
+    const loader = new AkeylessLoader();
+    await expect(loader.resolve('akeyless:/x')).rejects.toThrow(
+      /AKEYLESS_TOKEN/
+    );
+  });
+
+  it('should throw when response has no matching secret', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+    mockGetSecretValue.mockResolvedValueOnce({});
+
+    const loader = new AkeylessLoader();
+    await expect(loader.resolve('akeyless:/missing')).rejects.toThrow(
+      /No value/
+    );
+  });
+
+  it('should throw on invalid version argument', async () => {
+    process.env.AKEYLESS_TOKEN = 't';
+
+    const loader = new AkeylessLoader();
+    await expect(
+      loader.resolve('akeyless(version=not-a-number):/app/db')
+    ).rejects.toThrow(/version/);
+  });
+});

--- a/tests/loaders/AkeylessLoader.test.ts
+++ b/tests/loaders/AkeylessLoader.test.ts
@@ -103,6 +103,22 @@ describe('AkeylessLoader', () => {
     );
   });
 
+  it('should call /auth once when the same loader resolves multiple secrets', async () => {
+    process.env.AKEYLESS_ACCESS_ID = 'id';
+    process.env.AKEYLESS_ACCESS_KEY = 'key';
+    delete process.env.AKEYLESS_TOKEN;
+    mockAuth.mockResolvedValue({ token: 'tok', expiration: '4102444800000' });
+    mockGetSecretValue
+      .mockResolvedValueOnce({ '/a': '1' })
+      .mockResolvedValueOnce({ '/b': '2' });
+
+    const loader = new AkeylessLoader();
+    await expect(loader.resolve('akeyless:/a')).resolves.toBe('1');
+    await expect(loader.resolve('akeyless:/b')).resolves.toBe('2');
+    expect(mockAuth).toHaveBeenCalledTimes(1);
+    expect(mockGetSecretValue).toHaveBeenCalledTimes(2);
+  });
+
   it('should resolve using AKEYLESS_TOKEN without calling auth', async () => {
     process.env.AKEYLESS_TOKEN = 'pre-baked';
     delete process.env.AKEYLESS_ACCESS_ID;

--- a/tests/setup/slow-buffer-shim.js
+++ b/tests/setup/slow-buffer-shim.js
@@ -1,0 +1,14 @@
+'use strict';
+/**
+ * Node 21+ removed `SlowBuffer`. Legacy deps (e.g. jwa → buffer-equal-constant-time)
+ * still touch SlowBuffer.prototype at load time; Jest loads them when akeyless is required.
+ */
+const buffer = require('buffer');
+if (buffer.SlowBuffer == null && buffer.Buffer != null) {
+  Object.defineProperty(buffer, 'SlowBuffer', {
+    value: buffer.Buffer,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "tests/**/*",
-    "**/index.ts"
-  ]
+  "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
## Summary

This change adds an **Akeyless** source for static secrets using the official [`akeyless`](https://www.npmjs.com/package/akeyless) Node SDK and the `get-secret-value` API.

## Usage

In `.env` (or other supported inputs):

```
MY_SECRET = ${akeyless:/path/to/static-secret}
```

Optional arguments (same style as other loaders):

```
${akeyless(gateway=https://gateway.example.com:8080/v2,ignore-cache=true):/path/to/secret}
```

## Environment

| Variable | Purpose |
|----------|---------|
| `AKEYLESS_GATEWAY_URL` | API / Gateway base URL (default: `https://api.akeyless.io`) |
| `AKEYLESS_TOKEN` | If set, used for `get-secret-value` (skips `/auth`) |
| `AKEYLESS_ACCESS_ID` / `AKEYLESS_ACCESS_KEY` | Access-key auth when `AKEYLESS_TOKEN` is not set |

## Implementation notes

- The SDK is **lazy-`require`d** inside `resolve()` so importing `Loaders` does not load the full `akeyless` graph at module evaluation time (helps Jest and consumers that never use Akeyless).
- **Jest**: `tests/setup/slow-buffer-shim.js` plus `jest.config.js` `setupFiles` work around Node 21+ removing `SlowBuffer`, which breaks legacy transitive deps when the SDK is loaded in tests.
- **TypeScript**: `tsconfig.eslint.json` now includes `src/**/*` so `src/types/akeyless.d.ts` is part of the project used by `npm run type-check`.

## Testing

`npm run type-check` and `npx jest --watchAll=false` pass locally.

Refs: [Akeyless JavaScript SDK](https://docs.akeyless.io/docs/javascript-sdk)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new secrets backend with authenticated session caching and new dependency graph, plus changes to variable-expansion parsing; mistakes could lead to failed secret resolution or unexpected auth behavior across CLI runs.
> 
> **Overview**
> Adds an **Akeyless** loader (`AkeylessLoader`) supporting `akeyless:`, `akeyless_dynamic:`, and `akeyless_rotated:` secret references, including gateway/arg parsing, token vs access-key auth, and *per-run session reuse* to avoid repeated `/auth` calls.
> 
> Updates env interpolation to allow pipe-separated args inside `${...}` (needed for Akeyless dynamic args), wires the new loader into `Loaders`, and adds a `SlowBuffer` shim (and Jest `setupFiles` + eslint ignore) to keep tests working on Node 21+ when loading legacy transitive deps. Also bumps package version and adds the `akeyless` dependency with corresponding lockfile updates, and expands README docs for the new source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a548a7223a43513307d4f8d4655087335a949f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->